### PR TITLE
Update process-definition.json with new proseg container

### DIFF
--- a/community/proseg/1.0/process-definition.json
+++ b/community/proseg/1.0/process-definition.json
@@ -15,7 +15,7 @@
         "repository": "GITHUBPUBLIC",
         "script": "main.nf",
         "uri": "settylab/proseg-workflow",
-        "version": "eff5dcc"
+        "version": "ce59cc1"
     },
     "allowMultipleSources": false,
     "usesSampleSheet": false,


### PR DESCRIPTION
This update uses a new version of `main.nf` which explicitly specifies the version of the Proseg docker container to use