### PR TITLE
Add memory for MERGED_LIBRARY_BAM_TO_BIGWIG:BEDTOOLS_GENOMECOV

### DIFF
--- a/nf-core/atacseq/2.0/process-compute.config
+++ b/nf-core/atacseq/2.0/process-compute.config
@@ -6,3 +6,11 @@ profiles {
         }
     }
 }
+
+process {
+    withName: '.*:MERGED_LIBRARY_BAM_TO_BIGWIG:BEDTOOLS_GENOMECOV' {
+        cpus   = { check_max( 12    * task.attempt, 'cpus'    ) }
+        memory = { check_max( 72.GB * task.attempt, 'memory'  ) }
+        time   = { check_max( 16.h  * task.attempt, 'time'    ) }
+    }
+}


### PR DESCRIPTION
A user reported that this step ran out of memory, and so we would like to increase the amount of memory available.