### PR TITLE
FetchNGS fix for max file size

### DIFF
--- a/nf-core/fetchngs/1.7/process-compute.config
+++ b/nf-core/fetchngs/1.7/process-compute.config
@@ -38,5 +38,6 @@ process {
 
     withName: SRATOOLS_PREFETCH {
         container = "quay.io/biocontainers/sra-tools:3.0.9--h9f5acd7_0"
+        ext.args = '--max-size 200g'
     }
 }


### PR DESCRIPTION
Default is 20GB