### PR TITLE
Fix cell ranger pipeline when using public data

### DIFF
--- a/cirro/cellranger-flex/1.0/preprocess.py
+++ b/cirro/cellranger-flex/1.0/preprocess.py
@@ -12,7 +12,7 @@ ds.add_param(
     "s3://pubweb-references/cellranger/" + {
         "Homo sapiens (GRCh38-2024)": "refdata-gex-GRCh38-2024-A",
         "Homo sapiens (GRCh38-2020)": "refdata-gex-GRCh38-2020-A",
-        "Mus musculus (mm10-2024)": "refdata-gex-mm10-2024-A",
+        "Mus musculus (GRCm39-2024)": "refdata-gex-GRCm39-2024-A",
         "Mus musculus (mm10-2020)": "refdata-gex-mm10-2020-A"
     }[
         ds.params["reference"]

--- a/cirro/cellranger-flex/1.0/process-form.json
+++ b/cirro/cellranger-flex/1.0/process-form.json
@@ -10,7 +10,7 @@
         "enum": [
           "Homo sapiens (GRCh38-2024)",
           "Homo sapiens (GRCh38-2020)",
-          "Mus musculus (mm10-2024)",
+          "Mus musculus (GRCm39-2024)",
           "Mus musculus (mm10-2020)"
         ]
       },

--- a/cirro/cellranger-gex/1.0/process-form.json
+++ b/cirro/cellranger-gex/1.0/process-form.json
@@ -10,17 +10,17 @@
         "enum": [
           "s3://pubweb-references/cellranger/refdata-gex-GRCh38-2024-A",
           "s3://pubweb-references/cellranger/refdata-gex-GRCh38-2020-A",
-          "s3://pubweb-references/cellranger/refdata-gex-GRCh38-and-mm10-2024-A",
+          "s3://pubweb-references/cellranger/refdata-gex-GRCh38-and-GRCm39-2024-A",
           "s3://pubweb-references/cellranger/refdata-gex-GRCh38-and-mm10-2020-A",
-          "s3://pubweb-references/cellranger/refdata-gex-mm10-2024-A",
+          "s3://pubweb-references/cellranger/refdata-gex-GRCm39-2024-A",
           "s3://pubweb-references/cellranger/refdata-gex-mm10-2020-A"
         ],
         "enumNames": [
           "Homo sapiens (GRCh38-2024)",
           "Homo sapiens (GRCh38-2020)",
-          "Homo sapiens (GRCh38-2024) and Mus musculus (mm10-2024)",
+          "Homo sapiens (GRCh38-2024) and Mus musculus (GRCm39-2024)",
           "Homo sapiens (GRCh38-2020) and Mus musculus (mm10-2020)",
-          "Mus musculus (mm10-2024)",
+          "Mus musculus (GRCm39-2024)",
           "Mus musculus (mm10-2020)"
         ]
       },

--- a/cirro/cellranger-gex/fetchngs_1.0/preprocess.py
+++ b/cirro/cellranger-gex/fetchngs_1.0/preprocess.py
@@ -1,34 +1,12 @@
 #!/usr/bin/env python3
 
-from cirro.api.models.s3_path import S3Path
-from cirro.helpers.preprocess_dataset import PreprocessDataset
+from cirro.helpers.preprocess_dataset import PreprocessDataset, read_json
 from logging import Logger
-from pathlib import Path
 from typing import Union
-import boto3
-import json
 import pandas as pd
 
 
-def read_json(path):
-    """Read a JSON from S3."""
-
-    # Make the full S3 path
-    s3_path = S3Path(path)
-
-    if s3_path.valid:
-        s3 = boto3.client('s3')
-        retr = s3.get_object(Bucket=s3_path.bucket, Key=s3_path.key)
-        text = retr['Body'].read().decode()
-    else:
-        with Path(path).open() as handle:
-            text = handle.read()
-
-    # Parse JSON
-    return json.loads(text)
-
-
-def read_input_dataset(ds: PreprocessDataset):
+def read_input_dataset(ds: PreprocessDataset) -> list[dict]:
 
     # Get the list of files in the parent dataset
     manifest_fp = ds.params["input_dataset"] + "/web/manifest.json"
@@ -42,7 +20,7 @@ def read_input_dataset(ds: PreprocessDataset):
     return manifest
 
 
-def parse_fastq(r: pd.Series, suffix=".fastq.gz") -> Union[str, None]:
+def parse_fastq(r: dict, suffix=".fastq.gz") -> Union[dict, None]:
     """
     Check that the filename conforms to the expected structure.
     e.g. SRX3815835_SRR6860803_1.fastq.gz

--- a/cirro/cellranger-gex/fetchngs_1.0/process-input.json
+++ b/cirro/cellranger-gex/fetchngs_1.0/process-input.json
@@ -1,5 +1,5 @@
 {
-  "input_dataset": "$.inputs[0].dataPath",
+  "input_dataset": "$.inputs[0].s3",
   "transcriptome_dir": "$.dataset.params.transcriptome_dir",
   "include_introns": "$.dataset.params.include_introns",
   "cellranger_version": "$.dataset.params.cellranger_version",

--- a/cirro/cellranger-hashtagging/1.0/process-form.json
+++ b/cirro/cellranger-hashtagging/1.0/process-form.json
@@ -10,17 +10,17 @@
         "enum": [
           "s3://pubweb-references/cellranger/refdata-gex-GRCh38-2024-A",
           "s3://pubweb-references/cellranger/refdata-gex-GRCh38-2020-A",
-          "s3://pubweb-references/cellranger/refdata-gex-GRCh38-and-mm10-2024-A",
+          "s3://pubweb-references/cellranger/refdata-gex-GRCh38-and-GRCm39-2024-A",
           "s3://pubweb-references/cellranger/refdata-gex-GRCh38-and-mm10-2020-A",
-          "s3://pubweb-references/cellranger/refdata-gex-mm10-2024-A",
+          "s3://pubweb-references/cellranger/refdata-gex-GRCm39-2024-A",
           "s3://pubweb-references/cellranger/refdata-gex-mm10-2020-A"
         ],
         "enumNames": [
           "Homo sapiens (GRCh38-2024)",
           "Homo sapiens (GRCh38-2020)",
-          "Homo sapiens (GRCh38-2024) and Mus musculus (mm10-2024)",
+          "Homo sapiens (GRCh38-2024) and Mus musculus (GRCm39-2024)",
           "Homo sapiens (GRCh38-2020) and Mus musculus (mm10-2020)",
-          "Mus musculus (mm10-2024)",
+          "Mus musculus (GRCm39-2024)",
           "Mus musculus (mm10-2020)"
         ]
       },

--- a/cirro/cellranger-multi/1.0/process-form.json
+++ b/cirro/cellranger-multi/1.0/process-form.json
@@ -14,7 +14,7 @@
             "enum": [
               "s3://pubweb-references/cellranger/refdata-gex-GRCh38-2024-A",
               "s3://pubweb-references/cellranger/refdata-gex-GRCh38-2020-A",
-              "s3://pubweb-references/cellranger/refdata-gex-GRCh38-and-mm10-2024-A",
+              "s3://pubweb-references/cellranger/refdata-gex-GRCh38-and-GRCm39-2024-A",
               "s3://pubweb-references/cellranger/refdata-gex-GRCh38-and-mm10-2020-A",
               "s3://pubweb-references/cellranger/refdata-gex-GRCm39-2024-A",
               "s3://pubweb-references/cellranger/refdata-gex-mm10-2020-A"
@@ -22,7 +22,7 @@
             "enumNames": [
               "Homo sapiens (GRCh38-2024)",
               "Homo sapiens (GRCh38-2020)",
-              "Homo sapiens (GRCh38-2024) and Mus musculus (mm10-2024)",
+              "Homo sapiens (GRCh38-2024) and Mus musculus (GRCm39-2024)",
               "Homo sapiens (GRCh38-2020) and Mus musculus (mm10-2020)",
               "Mus musculus (GRCm39-2024)",
               "Mus musculus (mm10-2020)"

--- a/cirro/spaceranger-mkref/1.0/process-form.json
+++ b/cirro/spaceranger-mkref/1.0/process-form.json
@@ -11,13 +11,13 @@
         "enum": [
           "s3://pubweb-references/cellranger/refdata-gex-GRCh38-2024-A",
           "s3://pubweb-references/cellranger/refdata-gex-GRCh38-2020-A",
-          "s3://pubweb-references/cellranger/refdata-gex-mm10-2024-A",
+          "s3://pubweb-references/cellranger/refdata-gex-GRCm39-2024-A",
           "s3://pubweb-references/cellranger/refdata-gex-mm10-2020-A"
         ],
         "enumNames": [
           "Homo sapiens (GRCh38-2024)",
           "Homo sapiens (GRCh38-2020)",
-          "Mus musculus (mm10-2024)",
+          "Mus musculus (GRCm39-2024)",
           "Mus musculus (mm10-2020)"
         ]
       },

--- a/nf-core/fetchngs/1.7/process-compute.config
+++ b/nf-core/fetchngs/1.7/process-compute.config
@@ -5,7 +5,7 @@ process {
     cpus   = { 1 * task.attempt }
     memory = { 6.GB * task.attempt }
 
-    errorStrategy = 'retry'
+    errorStrategy = { task.attempt <= 5 ? 'retry' : 'terminate' }
     maxRetries    = 5
     maxErrors     = '-1'
 

--- a/nf-core/fetchngs/1.7/process-compute.config
+++ b/nf-core/fetchngs/1.7/process-compute.config
@@ -5,8 +5,8 @@ process {
     cpus   = { 1 * task.attempt }
     memory = { 6.GB * task.attempt }
 
-    errorStrategy = { task.attempt <= 5 ? 'retry' : 'ignore' }
-    maxRetries    = 10
+    errorStrategy = 'retry'
+    maxRetries    = 5
     maxErrors     = '-1'
 
     // Process-specific resource requirements
@@ -33,7 +33,7 @@ process {
     }
     withLabel:error_retry {
         errorStrategy = 'retry'
-        maxRetries    = 10
+        maxRetries    = 5
     }
 
     withName: SRATOOLS_PREFETCH {


### PR DESCRIPTION
- `input_dataset` provided the wrong path
- Cleanup preprocess to use `read_json` function provided by SDK, cleanup some types
- Don't ignore fetchngs pipeline errors
- Fix reference name of 2024 mm10