### PR TITLE
Gracefully skip VEP-dbNSFP for genomes lacking that data

### DIFF
--- a/nf-core/sarek/3.1/preprocess.py
+++ b/nf-core/sarek/3.1/preprocess.py
@@ -191,11 +191,15 @@ if __name__ == "__main__":
 
     # dbNSFP
     if dbnsfp_param:
-        dbnsfp = f"s3://pubweb-references/VEP/{database[genome][0]}/dbNSFP4.2a_{database[genome][0].lower()}.gz"
-        dbnsfp_tbi = f"s3://pubweb-references/VEP/{database[genome][0]}/dbNSFP4.2a_{database[genome][0].lower()}.gz.tbi"
-        ds.add_param('dbnsfp', dbnsfp, overwrite=True)
-        ds.add_param('dbnsfp_tbi', dbnsfp_tbi, overwrite=True)
-        ds.add_param('dbnsfp_consequence', 'ALL', overwrite=True)
+        if genome in database:
+            dbnsfp = f"s3://pubweb-references/VEP/{database[genome][0]}/dbNSFP4.2a_{database[genome][0].lower()}.gz"
+            dbnsfp_tbi = f"s3://pubweb-references/VEP/{database[genome][0]}/dbNSFP4.2a_{database[genome][0].lower()}.gz.tbi"
+            ds.add_param('dbnsfp', dbnsfp, overwrite=True)
+            ds.add_param('dbnsfp_tbi', dbnsfp_tbi, overwrite=True)
+            ds.add_param('dbnsfp_consequence', 'ALL', overwrite=True)
+        else:
+            ds.logger.warning(f"No dbNSFP reference genome found for {genome} -- removing dbNSFP plugin")
+            ds.remove_param('vep_dbnsfp')
 
     # Splice AI
     if spliceai:


### PR DESCRIPTION
The current behavior is to raise an error, which may not be helpful for users who cannot find the checkbox to deselect in the list of input options.