### PR TITLE
Stage uniquely named VCF copies to fix Mutect2 input file name collision in sarek

### DIFF
--- a/nf-core/sarek/3.1/preprocess.py
+++ b/nf-core/sarek/3.1/preprocess.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 
 from cirro.helpers.preprocess_dataset import PreprocessDataset
+from cirro.models.s3_path import S3Path
+import boto3
 import pandas as pd
+from pathlib import Path
 from typing import List
 import urllib.request
 import urllib.error
@@ -331,6 +334,70 @@ def resolve_reference_genome(ds: PreprocessDataset):
         ds.logger.info(f"genome_source=igenomes: genome={ds.params.get('genome')!r}")
 
 
+# VCF params handed to Mutect2, each paired with the index param that must accompany
+# it. Both entries can resolve to files with the same name — the Cirro reference
+# library only offers germline_resource.vcf.gz as a VCF, so selecting it for the panel
+# of normals as well makes --pon and --germline_resource collide.
+_VCF_PARAM_PAIRS = (
+    ("germline_resource", "germline_resource_tbi"),
+    ("pon", "pon_tbi"),
+)
+
+
+def stage_colliding_vcf_params(ds: PreprocessDataset):
+    """Stage uniquely named local copies of VCF params whose file names collide.
+
+    Nextflow stages every input of a process into a single work directory, so two
+    params pointing at files with the same name abort the run:
+
+        Process ...:MUTECT2_PAIRED input file name collision -- There are multiple
+        input files for each of the following file names: germline_resource.vcf.gz
+
+    Copy each offending VCF into the launch directory under a name prefixed with its
+    param key and repoint the param at that copy. The index is staged as
+    ``<staged_vcf>.tbi`` because GATK requires it to sit next to the VCF under a
+    matching name; where no index param is set, sarek indexes the staged copy itself.
+    Nextflow uploads these local inputs to the work directory on demand.
+    """
+    paths = {
+        vcf_param: ds.params[vcf_param]
+        for vcf_param, _ in _VCF_PARAM_PAIRS
+        if ds.params.get(vcf_param)
+    }
+
+    by_name = {}
+    for vcf_param, path in paths.items():
+        by_name.setdefault(path.rsplit("/", 1)[-1], []).append(vcf_param)
+
+    colliding = {
+        vcf_param
+        for vcf_params in by_name.values() if len(vcf_params) > 1
+        for vcf_param in vcf_params
+    }
+    if not colliding:
+        ds.logger.info("VCF inputs: no file name collisions to resolve")
+        return
+
+    ds.logger.info(f"VCF inputs: resolving file name collision between {sorted(colliding)}")
+
+    s3 = boto3.client("s3")
+    for vcf_param, tbi_param in _VCF_PARAM_PAIRS:
+        if vcf_param not in colliding:
+            continue
+
+        staged_vcf = f"{vcf_param}_{paths[vcf_param].rsplit('/', 1)[-1]}"
+        to_stage = [(vcf_param, paths[vcf_param], staged_vcf)]
+        if ds.params.get(tbi_param):
+            to_stage.append((tbi_param, ds.params[tbi_param], f"{staged_vcf}.tbi"))
+
+        for param, uri, local_name in to_stage:
+            source = S3Path(uri)
+            assert source.valid, f"Cannot stage a copy of --{param}: {uri} is not an S3 path"
+            ds.logger.info(f"VCF inputs: staging {uri} as {local_name}")
+            s3.download_file(source.bucket, source.key, local_name)
+            ds.add_param(param, str(Path(local_name).resolve()), overwrite=True)
+
+
 _DEFAULT_WORKFLOW_VERSION = "3.8.1"
 
 # Params that the extra JSON input field must never override.
@@ -642,6 +709,10 @@ if __name__ == "__main__":
     # These are added before schema filtering so that invalid keys are
     # automatically removed in the next step rather than causing Nextflow errors.
     apply_extra_json_params(ds)
+
+    # Give the Mutect2 VCF params distinct file names, now that every source of a
+    # germline_resource/pon value (form, iGenomes defaults, extra JSON) has been applied.
+    stage_colliding_vcf_params(ds)
 
     # Remove any parameters not defined in the nf-core/sarek nextflow_schema.json for
     # the selected workflow version. This also cleans up Cirro-only housekeeping params

--- a/nf-core/sarek_call_variants/3/preprocess.py
+++ b/nf-core/sarek_call_variants/3/preprocess.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 
 from cirro.helpers.preprocess_dataset import PreprocessDataset
+from cirro.models.s3_path import S3Path
+import boto3
 import pandas as pd
+from pathlib import Path
 import urllib.request
 import urllib.error
 import json
@@ -277,6 +280,70 @@ def resolve_reference_genome(ds: PreprocessDataset):
         ds.logger.info(f"genome_source=igenomes: genome={ds.params.get('genome')!r}")
 
 
+# VCF params handed to Mutect2, each paired with the index param that must accompany
+# it. Both entries can resolve to files with the same name — the Cirro reference
+# library only offers germline_resource.vcf.gz as a VCF, so selecting it for the panel
+# of normals as well makes --pon and --germline_resource collide.
+_VCF_PARAM_PAIRS = (
+    ("germline_resource", "germline_resource_tbi"),
+    ("pon", "pon_tbi"),
+)
+
+
+def stage_colliding_vcf_params(ds: PreprocessDataset):
+    """Stage uniquely named local copies of VCF params whose file names collide.
+
+    Nextflow stages every input of a process into a single work directory, so two
+    params pointing at files with the same name abort the run:
+
+        Process ...:MUTECT2_PAIRED input file name collision -- There are multiple
+        input files for each of the following file names: germline_resource.vcf.gz
+
+    Copy each offending VCF into the launch directory under a name prefixed with its
+    param key and repoint the param at that copy. The index is staged as
+    ``<staged_vcf>.tbi`` because GATK requires it to sit next to the VCF under a
+    matching name; where no index param is set, sarek indexes the staged copy itself.
+    Nextflow uploads these local inputs to the work directory on demand.
+    """
+    paths = {
+        vcf_param: ds.params[vcf_param]
+        for vcf_param, _ in _VCF_PARAM_PAIRS
+        if ds.params.get(vcf_param)
+    }
+
+    by_name = {}
+    for vcf_param, path in paths.items():
+        by_name.setdefault(path.rsplit("/", 1)[-1], []).append(vcf_param)
+
+    colliding = {
+        vcf_param
+        for vcf_params in by_name.values() if len(vcf_params) > 1
+        for vcf_param in vcf_params
+    }
+    if not colliding:
+        ds.logger.info("VCF inputs: no file name collisions to resolve")
+        return
+
+    ds.logger.info(f"VCF inputs: resolving file name collision between {sorted(colliding)}")
+
+    s3 = boto3.client("s3")
+    for vcf_param, tbi_param in _VCF_PARAM_PAIRS:
+        if vcf_param not in colliding:
+            continue
+
+        staged_vcf = f"{vcf_param}_{paths[vcf_param].rsplit('/', 1)[-1]}"
+        to_stage = [(vcf_param, paths[vcf_param], staged_vcf)]
+        if ds.params.get(tbi_param):
+            to_stage.append((tbi_param, ds.params[tbi_param], f"{staged_vcf}.tbi"))
+
+        for param, uri, local_name in to_stage:
+            source = S3Path(uri)
+            assert source.valid, f"Cannot stage a copy of --{param}: {uri} is not an S3 path"
+            ds.logger.info(f"VCF inputs: staging {uri} as {local_name}")
+            s3.download_file(source.bucket, source.key, local_name)
+            ds.add_param(param, str(Path(local_name).resolve()), overwrite=True)
+
+
 _DEFAULT_WORKFLOW_VERSION = "3.8.1"
 
 # Params set by Cirro infrastructure or computed by this script that must not
@@ -531,6 +598,11 @@ if __name__ == "__main__":
     ds.remove_param('wes')
 
     apply_extra_json_params(ds)
+
+    # Give the Mutect2 VCF params distinct file names, now that every source of a
+    # germline_resource/pon value (form, iGenomes defaults, extra JSON) has been applied.
+    stage_colliding_vcf_params(ds)
+
     filter_params_by_schema(ds)
 
     ds.logger.info(f"Final params ({len(ds.params)} total): {ds.params}")


### PR DESCRIPTION
## Problem

The Cirro UI resolves both `--pon` and `--germline_resource` from the reference library, and the only VCF reference type available is `germline_resource`. Selecting it for both params makes them resolve to two different files that share a name. Nextflow stages every input of a process into a single work directory, so the run aborts:

```
Process `NFCORE_SAREK:SAREK:BAM_VARIANT_CALLING_SOMATIC_ALL:BAM_VARIANT_CALLING_SOMATIC_MUTECT2:MUTECT2_PAIRED`
input file name collision -- There are multiple input files for each of the
following file names: germline_resource.vcf.gz.tbi, germline_resource.vcf.gz
```

## What changed

Added `stage_colliding_vcf_params()` to the sarek preprocess scripts. It groups the Mutect2 VCF params by basename, and for any basename claimed by more than one param it downloads the file into the Nextflow launch directory under `<param_key>_<basename>` and repoints the param at the absolute local path. Nextflow's foreign-file staging uploads those to the work dir — the same mechanism `manifest.csv` already relies on.

- `nf-core/sarek/3.1/preprocess.py`
- `nf-core/sarek_call_variants/3/preprocess.py`

## Reviewer notes

**The index is staged as `<staged_vcf>.tbi`, not `<tbi_param_key>_<basename>`.** GATK requires the index to sit beside the VCF under a matching name, so prefixing the `_tbi` params with their own key would have produced `germline_resource_tbi_germline_resource.vcf.gz.tbi` and broken Mutect2 a different way. When a param has no index set (the usual case for a user-supplied PON), only the VCF is staged and sarek's `TABIX_PON` indexes the renamed copy — that is what fixes the `germline_resource.vcf.gz.tbi` half of the error.

**Staging only happens on an actual basename collision.** The germline resource can be multi-GB, so an unconditional copy would download it on every somatic run. With the guard, the common case (germline resource set, PON from the iGenomes bundle or unset) copies nothing.

**Ordering.** It runs after `apply_extra_json_params()` so values injected through the Extra Parameters JSON field are covered too. A colliding path that is not on S3 raises rather than being silently left to collide.

**Scope.** Only these two pipelines have both params user-settable. `sarek_annotate/3.1` sets `pon`/`pon_tbi` from hardcoded iGenomes bundle paths and has no `germline_resource` param; `sarek_align/3.2` and `sarek_custom/3.5` have neither. Nothing can collide in those three, so they are untouched.

## Testing

Byte-compiled both scripts, then ran the function under a stubbed `PreprocessDataset` and `boto3` client across five cases: the reported collision (un-indexed PON), both params indexed, distinct filenames, germline resource alone, and a non-S3 path. Asserted that staged names are unique, every `.tbi` matches its VCF name, paths are absolute, and no download occurs without a collision. All passed for both scripts.

Not verified end-to-end: whether the headnode has disk headroom for the staged copies depends on the actual reference sizes. If that becomes a problem, the alternative is a server-side S3 copy into the dataset's own path — `community/mcmicro/1.0/preprocess.py:76` already does this with `s3.meta.client.copy`, which avoids local disk entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
