### PR TITLE
CS-180: Normalize sex values to XX/XY/NA in other sarek preprocess configs

### DIFF
--- a/nf-core/sarek/3.1/preprocess.py
+++ b/nf-core/sarek/3.1/preprocess.py
@@ -8,6 +8,27 @@ import urllib.error
 import json
 
 
+# Spellings of sex seen in user samplesheets, mapped to the XX/XY encoding sarek
+# requires. Anything else (including a blank cell) becomes NA.
+_SEX_ALIASES = {
+    'f': 'XX',
+    'female': 'XX',
+    'xx': 'XX',
+    'm': 'XY',
+    'male': 'XY',
+    'xy': 'XY',
+    'na': 'NA',
+    'unknown': 'NA',
+}
+
+
+def normalize_sex(value) -> str:
+    """Map a samplesheet sex value to sarek's XX/XY/NA encoding."""
+    if pd.isna(value):
+        return 'NA'
+    return _SEX_ALIASES.get(str(value).strip().lower(), 'NA')
+
+
 def make_manifest(ds: PreprocessDataset) -> pd.DataFrame:
 
     # Filter out any index files that may have been uploaded
@@ -49,10 +70,8 @@ def make_manifest(ds: PreprocessDataset) -> pd.DataFrame:
     if len(non_canonical) != 0:
         manifest = manifest.drop(columns=non_canonical)
 
-    # Set the default value for 'sex' to be NA
-    manifest = manifest.assign(
-        sex=manifest['sex'].fillna('NA')
-    )
+    # Normalize 'sex' to the XX/XY/NA encoding sarek requires, defaulting to NA
+    manifest = manifest.assign(sex=manifest["sex"].apply(normalize_sex))
 
     # Transform status values "Normal" -> 0 and "Tumor" -> 1
     manifest = manifest.replace(

--- a/nf-core/sarek_align/3.2/preprocess.py
+++ b/nf-core/sarek_align/3.2/preprocess.py
@@ -7,6 +7,27 @@ import urllib.error
 import json
 
 
+# Spellings of sex seen in user samplesheets, mapped to the XX/XY encoding sarek
+# requires. Anything else (including a blank cell) becomes the given default.
+_SEX_ALIASES = {
+    'f': 'XX',
+    'female': 'XX',
+    'xx': 'XX',
+    'm': 'XY',
+    'male': 'XY',
+    'xy': 'XY',
+    'na': 'NA',
+    'unknown': 'NA',
+}
+
+
+def normalize_sex(value, default: str = 'NA') -> str:
+    """Map a samplesheet sex value to sarek's XX/XY/NA encoding."""
+    if pd.isna(value):
+        return default
+    return _SEX_ALIASES.get(str(value).strip().lower(), default)
+
+
 def make_manifest(ds: PreprocessDataset) -> pd.DataFrame:
 
     # Filter out any index files that may have been uploaded
@@ -29,7 +50,8 @@ def make_manifest(ds: PreprocessDataset) -> pd.DataFrame:
     # Get the sample metadata (if any)
     # Populate the 'patient' column with the provided value,
     # falling back to the sample ID if missing.
-    # Default 'sex' to "XX" and 'status' to 0 if not provided.
+    # Normalize 'sex' to the XX/XY/NA encoding sarek requires, defaulting to XX
+    # since alignment-only does not need sex differentiation. Default 'status' to 0.
     samplesheet = ds.samplesheet.reindex(columns=["sample", "patient", "sex", "status"])
     missing_status = samplesheet["status"].isna().sum()
     if missing_status > 0:
@@ -40,7 +62,7 @@ def make_manifest(ds: PreprocessDataset) -> pd.DataFrame:
     samples = (
         samplesheet
         .assign(patient=lambda d: d['patient'].fillna(d['sample']))
-        .assign(sex=lambda d: d['sex'].fillna("XX"))
+        .assign(sex=lambda d: d['sex'].apply(normalize_sex, default='XX'))
         .assign(status=lambda d: d['status'].fillna(0).astype(int))
         .set_index("sample")
     )

--- a/nf-core/sarek_custom/3.5/preprocess.py
+++ b/nf-core/sarek_custom/3.5/preprocess.py
@@ -7,6 +7,27 @@ import urllib.error
 import json
 
 
+# Spellings of sex seen in user samplesheets, mapped to the XX/XY encoding sarek
+# requires. Anything else (including a blank cell) becomes NA.
+_SEX_ALIASES = {
+    'f': 'XX',
+    'female': 'XX',
+    'xx': 'XX',
+    'm': 'XY',
+    'male': 'XY',
+    'xy': 'XY',
+    'na': 'NA',
+    'unknown': 'NA',
+}
+
+
+def normalize_sex(value) -> str:
+    """Map a samplesheet sex value to sarek's XX/XY/NA encoding."""
+    if pd.isna(value):
+        return 'NA'
+    return _SEX_ALIASES.get(str(value).strip().lower(), 'NA')
+
+
 def make_manifest(ds: PreprocessDataset) -> pd.DataFrame:
 
     # Filter out any index files that may have been uploaded
@@ -41,10 +62,8 @@ def make_manifest(ds: PreprocessDataset) -> pd.DataFrame:
         for i in range(manifest.shape[0])
     ])
 
-    # Set the default value for 'sex' to be NA
-    manifest = manifest.assign(
-        sex=manifest['sex'].fillna('NA')
-    )
+    # Normalize 'sex' to the XX/XY/NA encoding sarek requires, defaulting to NA
+    manifest = manifest.assign(sex=manifest["sex"].apply(normalize_sex))
 
     # Transform status values "Normal" -> 0 and "Tumor" -> 1
     manifest = manifest.replace(


### PR DESCRIPTION
## Summary

PR #85 normalized sarek samplesheet `sex` values (male/female/f/m/etc.) to sarek's required `XX`/`XY` encoding in `nf-core/sarek_call_variants/3/preprocess.py`. This extends the same fix to the other sarek preprocess configs that have the same problem:

- `nf-core/sarek/3.1/preprocess.py` — had `fillna('NA')` only; unnormalized values fail the somatic-path `sex in ['XX','XY','NA']` assertion. Same fix as #85 (default `NA`).
- `nf-core/sarek_custom/3.5/preprocess.py` — same `fillna('NA')` pattern; unnormalized values reach sarek directly and fail there. Same fix (default `NA`).
- `nf-core/sarek_align/3.2/preprocess.py` — defaults missing sex to `"XX"` (alignment-only doesn't need sex differentiation), but had no alias mapping at all, so `male`/`female` passed through unmodified and failed sarek's samplesheet schema validation (`Error for field 'sex' (male): Expected any of [[XX, XY, NA]]`). Uses the same alias table, with `normalize_sex` parameterized to default to `XX` instead of `NA`.

`nf-core/quantms_dda_lfq/1.0/preprocess.py` also references `"sex"`, but as an SDRF proteomics characteristic-column name unrelated to sarek's genotype encoding — not touched.

## Test plan

- [x] `python3 -m py_compile` on all three modified files
- [x] Traced `normalize_sex` mapping by hand for representative inputs (`male`, `female`, `F`, `xy`, missing, `unknown`)
- No existing test suite covers these preprocess scripts (matching precedent from #85)

🤖 Generated with [Claude Code](https://claude.com/claude-code)