### PR TITLE
CI-673 (CI-1817): Add executionModes to the process definition schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,7 @@ Key fields:
 | `childProcessIds` | Process IDs that can consume this process's output |
 | `dataType` | Human-readable output data type label |
 | `executor` | `"NEXTFLOW"` for pipeline processes, `"INGEST"` for intake processes |
+| `executionModes` | Optional. Where the process can run: `["STANDARD"]` (AWS Batch), `["PERFORMANCE"]` (AWS HealthOmics), or both. Omit to declare Standard only |
 | `category` | UI grouping (e.g. `"Reference Data"`) |
 | `code.repository` | `"GITHUBPUBLIC"` or `"NA"` |
 | `code.uri` | GitHub repo (e.g. `"CirroBio/nf-index-genome"`) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ Key fields:
 | `childProcessIds` | Process IDs that can consume this process's output |
 | `dataType` | Human-readable output data type label |
 | `executor` | `"NEXTFLOW"` for pipeline processes, `"INGEST"` for intake processes |
-| `executionModes` | Optional. Where the process can run: `["STANDARD"]` (AWS Batch), `["PERFORMANCE"]` (AWS HealthOmics), or both. Omit to declare Standard only |
+| `executionModes` | Optional. Where the process can run: `["STANDARD"]` (AWS Batch), `["HEALTHOMICS"]` (AWS HealthOmics), or both. Omit to declare Standard only |
 | `category` | UI grouping (e.g. `"Reference Data"`) |
 | `code.repository` | `"GITHUBPUBLIC"` or `"NA"` |
 | `code.uri` | GitHub repo (e.g. `"CirroBio/nf-index-genome"`) |

--- a/schemas/process-definition.schema.json
+++ b/schemas/process-definition.schema.json
@@ -271,8 +271,8 @@
   "definitions": {
     "executionMode": {
       "type": "string",
-      "description": "Where the process can run: STANDARD is AWS Batch, PERFORMANCE is AWS HealthOmics.",
-      "enum": ["STANDARD", "PERFORMANCE"]
+      "description": "Where the process can run: STANDARD is AWS Batch, HEALTHOMICS is AWS HealthOmics.",
+      "enum": ["STANDARD", "HEALTHOMICS"]
     },
     "executorType": {
       "description": "How the workflow is executed",

--- a/schemas/process-definition.schema.json
+++ b/schemas/process-definition.schema.json
@@ -135,6 +135,14 @@
       "description": "Specifies if the process can accept the Cirro-provided sample sheet.",
       "type": "boolean"
     },
+    "executionModes": {
+      "description": "Execution modes the process supports. Omit to declare Standard only.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/definitions/executionMode"
+      }
+    },
     "computeDefaults": {
       "description": "Defines the compute config for the process. Currently, only one entry is used.",
       "maxItems": 1,
@@ -261,9 +269,14 @@
     }
   },
   "definitions": {
+    "executionMode": {
+      "type": "string",
+      "description": "Where the process can run: STANDARD is AWS Batch, PERFORMANCE is AWS HealthOmics.",
+      "enum": ["STANDARD", "PERFORMANCE"]
+    },
     "executorType": {
       "description": "How the workflow is executed",
-      "enum": ["NEXTFLOW", "CROMWELL", "INGEST", "OMICS_READY2RUN"]
+      "enum": ["NEXTFLOW", "CROMWELL", "INGEST"]
     },
     "repositoryType": {
       "type": "string",


### PR DESCRIPTION
Adds an optional `executionModes` key to the pipeline definition schema, so a definition can declare whether it runs on AWS Batch ("STANDARD"), AWS HealthOmics ("HEALTHOMICS"), or both. Inert until definitions are stamped and the backend reads the attribute.

## Summary

- The key is optional and stays out of the root `required` array: every definition that exists today omits it, and an omitted key means Standard only once the backend attribute lands.
- `minItems: 1` rejects an empty declaration. "Runs nowhere" is never a legal value, and the backend API rejects the same empty list, so the two write paths agree.
- The enum values are upper case by contract, not by style: the backend decodes stored strings into a Java enum case-sensitively, and this schema is the only validation on the definition ingestion path.
- Removes `OMICS_READY2RUN` from the executor enum. No definition file in this repo or Cirro-resources has used it since the Ready2Run delisting, so the schema stops accepting new ones. The Java `Executor` value stays: archived Ready2Run records still carry it in storage, and the backend must keep decoding stored values.
- The new `executionMode` definition declares `"type": "string"` like `repositoryType`, rather than the untyped form its neighbor `executorType` uses. The inconsistency with the neighbor is deliberate; the typed form is stricter.
- Also documents the key in this repo's CLAUDE.md field table, which is the working reference for anyone hand-editing a definition.

## Test plan

- `python validate.py` over the whole repo: all four validation groups pass. Because the validator checks every process-definition.json against the schema, this run also proves no live definition used the removed executor value.
- Scratch copies of `community/proseg/1.0/process-definition.json` validated against the schema (copies outside the repo, not committed): `["STANDARD","HEALTHOMICS"]` accepted; `[]` rejected on `minItems`; `["TURBO"]` rejected on the enum.
- Not covered: nothing consumes the key yet. The backend attribute and the Cirro-resources submodule bump land separately.
