### PR TITLE
CS-192: Double GETPILEUPSUMMARIES memory in sarek Mutect2 configs

### DIFF
--- a/nf-core/sarek/3.1/process-compute.config
+++ b/nf-core/sarek/3.1/process-compute.config
@@ -97,6 +97,9 @@ process{
         queue        = "${PW_ONDEMAND_JOB_QUEUE}"
         ext.args     = "--OPTICAL_DUPLICATE_PIXEL_DISTANCE ${params.optical_duplicate_pixel_distance}"
     }
+    withName: 'GETPILEUPSUMMARIES.*' {
+        memory       = { check_max( 30.GB * task.attempt, 'memory' ) }
+    }
     withName: 'FREEBAYES|SAMTOOLS_STATS|SAMTOOLS_INDEX|UNZIP' {
         cpus         = { check_max( 4 * params.compute_multiplier * task.attempt, 'cpus' ) }
         memory       = { check_max( 30.GB * params.compute_multiplier * task.attempt, 'memory' ) }

--- a/nf-core/sarek_call_variants/3/process-compute.config
+++ b/nf-core/sarek_call_variants/3/process-compute.config
@@ -87,6 +87,9 @@ process{
         time         = { check_max( 48.h * params.compute_multiplier, 'time' ) }
         queue        = "${PW_ONDEMAND_JOB_QUEUE}"
     }
+    withName: 'GETPILEUPSUMMARIES.*' {
+        memory       = { check_max( 30.GB * task.attempt, 'memory' ) }
+    }
     withName: 'FREEBAYES|SAMTOOLS_STATS|SAMTOOLS_INDEX|UNZIP' {
         cpus         = { check_max( 4 * params.compute_multiplier * task.attempt, 'cpus' ) }
         memory       = { check_max( 30.GB * params.compute_multiplier * task.attempt, 'memory' ) }


### PR DESCRIPTION
`GATK4_GETPILEUPSUMMARIES` is tagged `process_low` upstream and had no override here, so it ran with 15 GB. That was running out on real data — sarek passes `task.memory` into `--java-options -Xmx`, so this directive bounds the JVM heap.

Doubles it to 30 GB in the two configs that expose `mutect2`:

```groovy
    withName: 'GETPILEUPSUMMARIES.*' {
        memory       = { check_max( 30.GB * task.attempt, 'memory' ) }
    }
```

- Selector is the one nf-core/sarek uses in `conf/modules/mutect2.config`; verified it matches the `_TUMOR`/`_NORMAL` aliases and not `GATHERPILEUPSUMMARIES_*`.
- `memory` only — `cpus`/`time` still come from `withLabel:process_low`.
- `sarek_align`, `sarek_annotate` and `sarek_custom` untouched; none of them expose `mutect2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)