### PR TITLE
Rename script file to main_bwamem2.nf

### DIFF
--- a/community/index_genomes/bwa-mem2/1.0/process-definition.json
+++ b/community/index_genomes/bwa-mem2/1.0/process-definition.json
@@ -14,7 +14,7 @@
     "repository": "GITHUBPUBLIC",
     "uri": "CirroBio/nf-index-genome",
     "version": "main",
-    "script": "main_bwa-mem2.nf"
+    "script": "main_bwamem2.nf"
   },
   "allowMultipleSources": false,
   "usesSampleSheet": false,


### PR DESCRIPTION
Cirro config was incorrectly pointing to main_bwa-mem2.nf, not [main_bwamem2.nf](https://github.com/CirroBio/nf-index-genome/blob/main/main_bwamem2.nf)